### PR TITLE
Added Component Testing

### DIFF
--- a/apps/native/cypress.config.ts
+++ b/apps/native/cypress.config.ts
@@ -3,17 +3,18 @@ import { defineConfig } from "cypress";
 export default defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
-      require('@cypress/code-coverage/task')(on, config)
+      require("@cypress/code-coverage/task")(on, config);
       // Use CI_BASE_URL if defined, otherwise fallback to 'http://localhost:3000'
-      config.baseUrl = process.env.CI_BASE_URL || 'http://localhost:19006';
+      config.baseUrl = process.env.CI_BASE_URL || "http://localhost:19006";
       return config;
     },
-    baseUrl: 'http://localhost:19006'
+    baseUrl: "http://localhost:19006",
   },
+
   component: {
     devServer: {
-      framework: "next",
-      bundler: "webpack",
+      framework: "react",
+      bundler: "vite",
     },
   },
 });

--- a/apps/native/cypress/support/component-index.html
+++ b/apps/native/cypress/support/component-index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>Components App</title>
+  </head>
+  <body>
+    <div data-cy-root></div>
+  </body>
+</html>

--- a/apps/native/cypress/support/component.ts
+++ b/apps/native/cypress/support/component.ts
@@ -1,0 +1,39 @@
+// ***********************************************************
+// This example support/component.ts is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')
+
+import { mount } from 'cypress/react18'
+
+// Augment the Cypress namespace to include type definitions for
+// your custom command.
+// Alternatively, can be defined in cypress/support/component.d.ts
+// with a <reference path="./component" /> at the top of your spec.
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      mount: typeof mount
+    }
+  }
+}
+
+Cypress.Commands.add('mount', mount)
+
+// Example use:
+// cy.mount(<MyComponent />)

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@fortawesome/react-fontawesome": "github:fortawesome/react-fontawesome",
+    "@originjs/vite-plugin-commonjs": "^1.0.3",
     "@react-native-async-storage/async-storage": "1.18.2",
     "@react-native-firebase/app": "^18.8.0",
     "@react-native-firebase/auth": "^18.8.0",
@@ -40,7 +41,8 @@
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.22.0",
     "react-native-vector-icons": "^10.0.3",
-    "react-native-web": "^0.19.10"
+    "react-native-web": "^0.19.10",
+    "vite": "^4.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.23.7",

--- a/apps/native/vite.config.ts
+++ b/apps/native/vite.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { viteCommonjs, esbuildCommonjs } from '@originjs/vite-plugin-commonjs'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  define: {
+    global: 'window',
+  },
+  optimizeDeps: {
+    include: ['@react-navigation/native'],
+    esbuildOptions: {
+      mainFields: ['module', 'main'],
+      resolveExtensions: ['.web.js', '.js', '.ts'],
+      plugins: [esbuildCommonjs(['@react-navigation/elements'])],
+    },
+  },
+  resolve: {
+    extensions: ['.web.tsx', '.web.jsx', '.web.js', '.tsx', '.ts', '.js'],
+    alias: {
+      'react-native': 'react-native-web',
+    },
+  },
+  plugins: [viteCommonjs(), react()],
+  build: {
+    commonjsOptions: {
+      transformMixedEsModules: true,
+    },
+  },
+})

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "node": ">=18"
   },
   "dependencies": {
+    "@originjs/vite-plugin-commonjs": "^1.0.3",
+    "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.4.17",
     "expo-document-picker": "^11.10.1",
     "expo-image-picker": "~14.3.2",


### PR DESCRIPTION
Added component testing for the Cypress framework. Instead of loading the server, you must use the cy.mount(JSX) method which loads the JSX component specified to the screen. Then you can use normal cypress commands to test it's functionality.