### PR TITLE
[CV-430] - [WEB] Notification Badge Not Updating Unless Page Refreshes

### DIFF
--- a/packages/ui/src/DashboardNav.tsx
+++ b/packages/ui/src/DashboardNav.tsx
@@ -15,6 +15,7 @@ const DashboardNav = () => {
     const [isModalOpenUser, setIsModalOpenUser] = useState(false);
     const [isModalOpenNotifications, setIsModalOpenNotifications] = useState(false);
     const [unreadNotificationsCount, setUnreadNotificationsCount] = useState(0);
+    const [isLoading, setIsLoading] = useState(true);
     let userRole: any;
     if (typeof window !== 'undefined') {
         userRole = window.localStorage.getItem('userRole');
@@ -22,6 +23,7 @@ const DashboardNav = () => {
 
     useEffect(() => {
         const fetchNotifications = async () => {
+            setIsLoading(true);
             if (authUser) {
                 const { uid } = authUser;
 
@@ -39,6 +41,7 @@ const DashboardNav = () => {
                 });
                 setUnreadNotificationsCount(notificationsData.length);
             }
+            setIsLoading(false);
         };
 
         fetchNotifications();
@@ -115,9 +118,9 @@ const DashboardNav = () => {
                     </li>
                 ))}
             </ul>
-            {isModalOpenUser && <UserProfileModal user={authUser} onClose={toggleModalUser} />}
-            {isModalOpenNotifications && userRole != 'Condo Management Company' && <NotificationsModal user={authUser} onClose={toggleModalNotifications} />}
-            {isModalOpenNotifications && userRole === 'Condo Management Company' && <RequestsModal user={authUser} onClose={toggleModalNotifications} />}
+            {!isLoading && isModalOpenUser && <UserProfileModal user={authUser} onClose={toggleModalUser} />}
+            {!isLoading && isModalOpenNotifications && userRole != 'Condo Management Company' && <NotificationsModal user={authUser} onClose={toggleModalNotifications} setUnreadNotificationsCount={setUnreadNotificationsCount} />}
+            {!isLoading && isModalOpenNotifications && userRole === 'Condo Management Company' && <RequestsModal user={authUser} onClose={toggleModalNotifications} />}
         </nav>
     );
 };

--- a/packages/ui/src/NotificationsModal.tsx
+++ b/packages/ui/src/NotificationsModal.tsx
@@ -94,7 +94,7 @@ const useNotifications = () => {
     return {notifications, setNotifications};
 };
 
-const NotificationsModal = ({onClose}: any) => {
+const NotificationsModal = ({onClose, setUnreadNotificationsCount}: any) => {
     const {notifications, setNotifications} = useNotifications();
     const [properties, setProperties] = useState([]);
 
@@ -131,6 +131,7 @@ const NotificationsModal = ({onClose}: any) => {
         if (!uid) return;
         const notificationDocRef = doc(db, "users", uid, "notifications", id.toString());
         await updateDoc(notificationDocRef, {markAsRead: true});
+        setUnreadNotificationsCount((prevCount:any) => Math.max(prevCount - 1, 0));
     };
 
     const [isRequestBoxVisible, setRequestBoxVisible] = useState(false);


### PR DESCRIPTION
Steps to reproduce:
Sign in as a user that contains notifications not read. Open Notification Modal and note the badge number in the navbar. When clicking on "Mark as Read" for any notification, you will notice that the badge in the navbar representing the amount of unread notifications is not updated unless refreshing the page.

**Before:

https://github.com/XavierGuertin/CondoVision/assets/36805808/228f241f-a898-42fd-80bf-4260674f2968

After:**

https://github.com/XavierGuertin/CondoVision/assets/36805808/580fea3b-8a72-48b4-a5fe-6a273f0b49e7
